### PR TITLE
chore(renovate): extend shared owine/renovate-config presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,52 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices",
-    ":semanticCommits"
+    "github>owine/renovate-config",
+    "github>owine/renovate-config:automerge",
+    "github>owine/renovate-config:node",
+    "github>owine/renovate-config:docker"
   ],
-  "semanticCommitType": "deps",
-  "semanticCommitScope": null,
-  "timezone": "America/Chicago",
-  "schedule": [
-    "on monday"
-  ],
-  "automergeSchedule": [
-    "at any time"
-  ],
-  "prHourlyLimit": 0,
-  "prConcurrentLimit": 0,
-  "lockFileMaintenance": {
-    "automerge": true
-  },
   "packageRules": [
     {
-      "description": "Group all non-major updates into a single PR",
-      "matchUpdateTypes": [
-        "patch",
-        "minor",
-        "pin",
-        "digest"
-      ],
-      "matchPackageNames": [
-        "!@modelcontextprotocol/sdk"
-      ],
-      "groupName": "all non-major dependencies",
-      "automerge": true
-    },
-    {
-      "description": "MCP SDK — feat prefix for minor bump, always review",
-      "matchPackageNames": [
-        "@modelcontextprotocol/sdk"
-      ],
+      "description": "MCP SDK — review every bump manually. Carved out of the non-major automerge bundle and uses `feat:` prefix so a minor SDK bump triggers a minor release-please bump.",
+      "matchPackageNames": ["@modelcontextprotocol/sdk"],
+      "groupName": "mcp-sdk",
       "semanticCommitType": "feat",
-      "automerge": false
-    },
-    {
-      "description": "Never automerge major bumps",
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "automerge": false
+      "automerge": false,
+      "addLabels": ["needs-review"]
     }
   ]
 }


### PR DESCRIPTION
Replaces the per-repo config with extends to [github>owine/renovate-config](https://github.com/owine/renovate-config) — supply-chain hardened defaults applied centrally.

## What this PR does
- Extends `default` + `automerge` + `node` + `docker` presets
- Drops boilerplate now in the shared preset (schedule, semantic commits, range pinning, lockfile maintenance, major-bump policy)
- Keeps only the MCP SDK carve-out: `feat:` prefix, no automerge, separate group

## New protections inherited from the preset
- `rangeStrategy: pin` — no caret ranges
- `minimumReleaseAge: 3 days` global (7 days for majors)
- `vulnerabilityAlerts` skip the soak and automerge
- `helpers:pinGitHubActionDigests` + `osvVulnerabilityAlerts` + `security:openssf-scorecard`

## Test plan
- [ ] Renovate config validates (`renovate-config-validator` in CI)
- [ ] Next Renovate run produces sensible PRs

## Summary by Sourcery

Adopt shared owine/renovate-config presets and simplify local Renovate configuration.

CI:
- Extend shared Renovate presets for default, automerge, Node, and Docker updates while retaining a custom MCP SDK rule set.
- Remove redundant per-repository Renovate settings now covered by the shared configuration, inheriting stricter pinning and security-focused defaults.