### PR TITLE
ci: pin actions to patch tags so Renovate emits accurate comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6 # Renovate will pin to SHA on first scan
+      - uses: pnpm/action-setup@v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
@@ -36,7 +36,7 @@ jobs:
           - '24.15.0' # renovate: datasource=node-version depName=node
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      - uses: pnpm/action-setup@v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '22.22.2' # renovate: datasource=node-version depName=node
-          - '24.15.0' # renovate: datasource=node-version depName=node
+          - '22.22.1' # renovate: datasource=node-version depName=node-lts-22 packageName=node
+          - '24.14.0' # renovate: datasource=node-version depName=node-lts-24 packageName=node
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: pnpm/action-setup@v6.0.8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+      - uses: googleapis/release-please-action@v5.0.0
         id: release
         with:
           config-file: release-please-config.json
@@ -32,7 +32,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6 # Renovate will pin to SHA on first scan
+      - uses: pnpm/action-setup@v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc


### PR DESCRIPTION
## Summary
Reverts `pnpm/action-setup` (3 lines) and `googleapis/release-please-action` from `@<sha> # vN` (major-only comment, some with stale Renovate TODOs) to patch tags (`@v6.0.8`, `@v5.0.0`) so Renovate re-pins to SHA with accurate `# vX.Y.Z` comments.

## Test plan
- [ ] Renovate's next scan re-pins to SHA with accurate patch comments