### PR TITLE
build(renovate): extend shared :mcp preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,23 +4,7 @@
     "github>owine/renovate-config",
     "github>owine/renovate-config:automerge",
     "github>owine/renovate-config:node",
+    "github>owine/renovate-config:mcp",
     "github>owine/renovate-config:docker"
-  ],
-  "packageRules": [
-    {
-      "description": "MCP SDK — review every bump manually. Carved out of the non-major automerge bundle and uses `feat:` prefix so a minor SDK bump triggers a minor release-please bump.",
-      "matchPackageNames": ["@modelcontextprotocol/sdk"],
-      "groupName": "mcp-sdk",
-      "semanticCommitType": "feat",
-      "automerge": false,
-      "addLabels": ["needs-review"]
-    },
-    {
-      "description": "Don't pin engines.node — this is a library and the engines range must stay broad for consumers. Overrides the node preset's default pin behavior.",
-      "matchManagers": ["npm"],
-      "matchDepTypes": ["engines"],
-      "matchPackageNames": ["node"],
-      "enabled": false
-    }
   ]
 }


### PR DESCRIPTION
Fleet Renovate audit follow-up. Depends on owine/renovate-config#6 (merged).

The `mcp-sdk` manual-review rule and the `engines.node` no-pin rule were **byte-identical** in this repo and `unifi-network-mcp`'s sibling. Both now live in the shared `github>owine/renovate-config:mcp` preset.

This PR drops the duplicated `packageRules` and adds `:mcp` to `extends` (after `:node`, before `:docker`). Net effect on resolved config: **zero** — same rules, single source of truth. Validated with `renovate-config-validator --strict` against the live preset.

## Summary by Sourcery

Build:
- Update Renovate config to remove locally duplicated package rules now provided by the shared :mcp preset.