### PR TITLE
ci: add stable test aggregator for matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - run: pnpm run lint
       - run: pnpm run build
 
-  test:
+  test-matrix:
     needs: lint
     runs-on: ubuntu-24.04
     strategy:
@@ -44,6 +44,22 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
       - run: pnpm test
+
+  # Aggregator with a stable name so branch rulesets can require a single `test`
+  # check regardless of how the matrix dimensions change.
+  test:
+    needs: test-matrix
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Verify matrix succeeded
+        env:
+          MATRIX_RESULT: ${{ needs.test-matrix.result }}
+        run: |
+          if [ "$MATRIX_RESULT" != "success" ]; then
+            echo "test-matrix did not succeed: $MATRIX_RESULT"
+            exit 1
+          fi
 
   security:
     # Skip on Renovate runs — Renovate runs its own vulnerability checks


### PR DESCRIPTION
## Summary
- Adds a `test` aggregator job that depends on the existing matrix (now renamed to `test-matrix`) and only succeeds when every matrix variant passes.
- Gives branch rulesets a single, stable required-check name to gate on, instead of the version-pinned `test (22.x.y)` / `test (24.x.y)` names that change every time Renovate bumps a Node LTS.

## Test plan
- [ ] CI runs `lint` → `test-matrix (22.22.3)`, `test-matrix (24.15.0)` → `test` aggregator → `security`.
- [ ] All three test-related checks (`test-matrix (22.x)`, `test-matrix (24.x)`, `test`) appear green on this PR.
- [ ] After merge, the new branch ruleset that requires `lint` + `test` works on the next Renovate PR without manual updates when Node versions bump.

## Summary by Sourcery

Add a stable test aggregator job in CI that depends on the test matrix to provide a single required check name for branch protection rules.

CI:
- Rename the existing test job to test-matrix and keep it as the matrix-based test runner.
- Introduce a new test aggregator job that depends on test-matrix and fails if any matrix variant fails.