### PR TITLE
ci: use GitHub App token in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,20 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
+      # Mint a GitHub App installation token so release-please's PRs/tags are
+      # authored by the App, not the default GITHUB_TOKEN. PRs created by the
+      # default token cannot trigger other workflows (GitHub's anti-recursion
+      # guard), which is why CI never ran on prior release PRs.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

Fixes #113 (and every future release PR) being unable to run the `lint` / `test` required checks.

**Root cause:** `release.yml` was opening release-please PRs with the default `GITHUB_TOKEN`. GitHub's anti-recursion guard prevents workflow-token-authored events from triggering other workflows, so `pull_request` on `ci.yml` never fired for those PRs. Only third-party app webhooks (GitGuardian, Sourcery) reported, leaving the ruleset's `lint` / `test` checks expected-but-missing → permanent BLOCKED.

**Fix:** Mint a GitHub App installation token via `actions/create-github-app-token` and pass it to `release-please-action`. PRs authored by a GitHub App *do* trigger downstream workflows. Mirrors the convention already in use on `nut-cgi`, `claude-terminal-home-assistant`, `MLB-Deferred-Contract-Calculator`, and `lsbrowser`.

## ⚠️ Required before merging

1. **Create a dedicated GitHub App for this repository** (one App per repo, per fleet policy — tighter blast radius if a key leaks).
2. **Install the App** on this repository only.
3. **Add two repository secrets** (fleet convention):
   - `RELEASE_APP_CLIENT_ID` — the App's **Client ID** string (looks like `Iv1.a1b2c3d4e5f6g7h8` or `lv23li…`, found on the App's settings page). **Not** the numeric App ID.
   - `RELEASE_APP_PRIVATE_KEY` — the App's downloaded `.pem` private key.

If you merge without these, the next push to `main` triggers a release.yml run that fails at the token-mint step. Nothing else breaks; release PRs just won't update until secrets are in place.

## Required App permissions

`Contents: write` + `Pull requests: write` at minimum. No org-level permissions required.

## Test plan
- [ ] After merging this PR + adding secrets, push any conventional commit to `main`.
- [ ] CI completes on main → release.yml fires → release-please opens/updates the release PR.
- [ ] On the updated release PR, `lint` + `test` jobs now run (verify in the Checks tab).
- [ ] Once they pass, the release PR can merge through the ruleset without admin bypass.

## Follow-up for the existing stuck PR

#113 won't auto-recover — its existing SHA was authored by `GITHUB_TOKEN` and GitHub doesn't retroactively re-fire workflows. Once secrets are in place, either:
- Push any conventional commit to main → release-please regenerates the PR with App-authored commits → new SHA triggers CI, or
- Close + reopen the PR (the reopen event also re-fires `pull_request`).