### PR TITLE
Align with UniFi Network API 10.5.43

### DIFF
--- a/src/tools/acl.ts
+++ b/src/tools/acl.ts
@@ -124,15 +124,15 @@ export function registerAclTools(
           .optional()
           .describe("Protocols this ACL rule will be applied to (TCP, UDP). When null, applies to all protocols"),
         sourceFilter: z
-          .record(z.string(), z.unknown())
+          .unknown()
           .optional()
           .describe("Traffic source filter (opaque object — pass the structure the API expects)"),
         destinationFilter: z
-          .record(z.string(), z.unknown())
+          .unknown()
           .optional()
           .describe("Traffic destination filter (opaque object — pass the structure the API expects)"),
         enforcingDeviceFilter: z
-          .record(z.string(), z.unknown())
+          .unknown()
           .optional()
           .describe("IDs of the Switch-capable devices used to enforce the ACL rule. When null/omitted, the rule is provisioned to all switches on the site"),
         dryRun: z
@@ -180,15 +180,15 @@ export function registerAclTools(
           .optional()
           .describe("Protocols this ACL rule will be applied to (TCP, UDP). When null, applies to all protocols"),
         sourceFilter: z
-          .record(z.string(), z.unknown())
+          .unknown()
           .optional()
           .describe("Traffic source filter (opaque object — pass the structure the API expects)"),
         destinationFilter: z
-          .record(z.string(), z.unknown())
+          .unknown()
           .optional()
           .describe("Traffic destination filter (opaque object — pass the structure the API expects)"),
         enforcingDeviceFilter: z
-          .record(z.string(), z.unknown())
+          .unknown()
           .optional()
           .describe("IDs of the Switch-capable devices used to enforce the ACL rule. When null/omitted, the rule is provisioned to all switches on the site"),
         dryRun: z

--- a/src/tools/acl.ts
+++ b/src/tools/acl.ts
@@ -123,6 +123,18 @@ export function registerAclTools(
           .array(z.enum(["TCP", "UDP"]))
           .optional()
           .describe("Protocols this ACL rule will be applied to (TCP, UDP). When null, applies to all protocols"),
+        sourceFilter: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("Traffic source filter (opaque object — pass the structure the API expects)"),
+        destinationFilter: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("Traffic destination filter (opaque object — pass the structure the API expects)"),
+        enforcingDeviceFilter: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("IDs of the Switch-capable devices used to enforce the ACL rule. When null/omitted, the rule is provisioned to all switches on the site"),
         dryRun: z
           .boolean()
           .optional()
@@ -131,11 +143,14 @@ export function registerAclTools(
       outputSchema: aclRuleOutputSchema,
       annotations: WRITE_NOT_IDEMPOTENT,
     },
-    async ({ siteId, type, name, enabled, action, description, protocolFilter, dryRun }) => {
+    async ({ siteId, type, name, enabled, action, description, protocolFilter, sourceFilter, destinationFilter, enforcingDeviceFilter, dryRun }) => {
       try {
         const body: Record<string, unknown> = { type, name, enabled, action };
         if (description !== undefined) body.description = description;
         if (protocolFilter !== undefined) body.protocolFilter = protocolFilter;
+        if (sourceFilter !== undefined) body.sourceFilter = sourceFilter;
+        if (destinationFilter !== undefined) body.destinationFilter = destinationFilter;
+        if (enforcingDeviceFilter !== undefined) body.enforcingDeviceFilter = enforcingDeviceFilter;
         if (dryRun) return formatDryRun("POST", `/sites/${siteId}/acl-rules`, body);
         const data = await client.post(`/sites/${siteId}/acl-rules`, body);
         return formatSuccess(data, { structured: true });
@@ -164,6 +179,18 @@ export function registerAclTools(
           .array(z.enum(["TCP", "UDP"]))
           .optional()
           .describe("Protocols this ACL rule will be applied to (TCP, UDP). When null, applies to all protocols"),
+        sourceFilter: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("Traffic source filter (opaque object — pass the structure the API expects)"),
+        destinationFilter: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("Traffic destination filter (opaque object — pass the structure the API expects)"),
+        enforcingDeviceFilter: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("IDs of the Switch-capable devices used to enforce the ACL rule. When null/omitted, the rule is provisioned to all switches on the site"),
         dryRun: z
           .boolean()
           .optional()
@@ -172,11 +199,14 @@ export function registerAclTools(
       outputSchema: aclRuleOutputSchema,
       annotations: WRITE,
     },
-    async ({ siteId, aclRuleId, type, name, enabled, action, description, protocolFilter, dryRun }) => {
+    async ({ siteId, aclRuleId, type, name, enabled, action, description, protocolFilter, sourceFilter, destinationFilter, enforcingDeviceFilter, dryRun }) => {
       try {
         const body: Record<string, unknown> = { type, name, enabled, action };
         if (description !== undefined) body.description = description;
         if (protocolFilter !== undefined) body.protocolFilter = protocolFilter;
+        if (sourceFilter !== undefined) body.sourceFilter = sourceFilter;
+        if (destinationFilter !== undefined) body.destinationFilter = destinationFilter;
+        if (enforcingDeviceFilter !== undefined) body.enforcingDeviceFilter = enforcingDeviceFilter;
         if (dryRun) return formatDryRun("PUT", `/sites/${siteId}/acl-rules/${aclRuleId}`, body);
         const data = await client.put(
           `/sites/${siteId}/acl-rules/${aclRuleId}`,

--- a/src/tools/clients.ts
+++ b/src/tools/clients.ts
@@ -17,7 +17,7 @@ export function registerClientTools(
   server.registerTool(
     "unifi_list_clients",
     {
-      description: "List currently connected clients at a site. Returns per client: id, name, type (WIRED/WIRELESS/VPN/TELEPORT), macAddress, ipAddress, connectedAt, uplinkDeviceId (the switch/AP they're attached to), access.type. NOTE: verified against 10.4.55 — the Integration API client schema is minimal and identical across types; it does NOT expose signal strength, channel, or per-port binding. Use for: who's online right now. Disconnected/historical clients are NOT in the Integration API.",
+      description: "List currently connected clients at a site. Returns per client: id, name, type (WIRED/WIRELESS/VPN/TELEPORT), macAddress, ipAddress, connectedAt, uplinkDeviceId (the switch/AP they're attached to), access.type. NOTE: verified against 10.5.43 — the Integration API client schema is minimal and identical across types; it does NOT expose signal strength, channel, or per-port binding. Use for: who's online right now. Disconnected/historical clients are NOT in the Integration API.",
       inputSchema: {
         siteId: z.string().describe("Site ID"),
         offset: z

--- a/src/tools/devices.ts
+++ b/src/tools/devices.ts
@@ -77,7 +77,7 @@ export function registerDeviceTools(
   server.registerTool(
     "unifi_get_device_statistics",
     {
-      description: "Get latest live statistics for a device. Returns: uptimeSec, lastHeartbeatAt, nextHeartbeatAt, loadAverage1/5/15Min, cpuUtilizationPct, memoryUtilizationPct, uplink (txRateBps, rxRateBps), interfaces.radios[] for APs ({frequencyGHz, txRetriesPct}). NOTE: verified against 10.4.55 — the Integration API does NOT expose per-switch-port byte/error/PoE-power counters here; port-level live stats are unavailable. Use for: device health and AP radio metrics. For config (channel, power, port assignment), use unifi_get_device.",
+      description: "Get latest live statistics for a device. Returns: uptimeSec, lastHeartbeatAt, nextHeartbeatAt, loadAverage1/5/15Min, cpuUtilizationPct, memoryUtilizationPct, uplink (txRateBps, rxRateBps), interfaces.radios[] for APs ({frequencyGHz, txRetriesPct}). NOTE: verified against 10.5.43 — the Integration API does NOT expose per-switch-port byte/error/PoE-power counters here; port-level live stats are unavailable. Use for: device health and AP radio metrics. For config (channel, power, port assignment), use unifi_get_device.",
       inputSchema: {
         siteId: z.string().describe("Site ID"),
         deviceId: z.string().describe("Device ID"),
@@ -100,7 +100,7 @@ export function registerDeviceTools(
   server.registerTool(
     "unifi_list_pending_devices",
     {
-      description: "List devices pending adoption across all sites (global endpoint, not site-scoped). Returns: basic device info per pending device (macAddress, model, ipAddress, firmwareVersion, etc. — exact per-row schema is not rendered in the 10.4.55 docs). Use for: discovering new devices on the network before calling unifi_adopt_device.",
+      description: "List devices pending adoption across all sites (global endpoint, not site-scoped). Returns: basic device info per pending device (macAddress, model, ipAddress, firmwareVersion, etc. — exact per-row schema is not rendered in the 10.5.43 docs). Use for: discovering new devices on the network before calling unifi_adopt_device.",
       inputSchema: {
         offset: z
           .number()

--- a/src/tools/supporting.ts
+++ b/src/tools/supporting.ts
@@ -22,7 +22,7 @@ export function registerSupportingTools(
   server.registerTool(
     "unifi_list_wans",
     {
-      description: "List WAN interface definitions at a site. Returns: id, name only (verified against 10.4.55 — the Integration API exposes no live link status or throughput rates here). Use for: WAN inventory, multi-WAN topology.",
+      description: "List WAN interface definitions at a site. Returns: id, name only (verified against 10.5.43 — the Integration API exposes no live link status or throughput rates here). Use for: WAN inventory, multi-WAN topology.",
       inputSchema: {
         siteId: z.string().describe("Site ID"),
         offset: z
@@ -56,7 +56,7 @@ export function registerSupportingTools(
   server.registerTool(
     "unifi_list_vpn_tunnels",
     {
-      description: "List site-to-site VPN tunnels (IPsec, WireGuard, OpenVPN site-to-site) at a site. Returns: tunnel definitions per row (per-row schema not rendered in 10.4.55 docs — call to inspect). For roaming client VPN servers, see unifi_list_vpn_servers.",
+      description: "List site-to-site VPN tunnels (IPsec, WireGuard, OpenVPN site-to-site) at a site. Returns: tunnel definitions per row (per-row schema not rendered in 10.5.43 docs — call to inspect). For roaming client VPN servers, see unifi_list_vpn_servers.",
       inputSchema: {
         siteId: z.string().describe("Site ID"),
         offset: z

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -11,7 +11,7 @@ export function registerSystemTools(
   server.registerTool(
     "unifi_get_info",
     {
-      description: "Get UniFi Network application info. Returns: applicationVersion. NOTE: verified against 10.4.55 on a UniFi OS console — the Integration API returns ONLY applicationVersion here; there is no isUniFiOSConsole or other field. Use for: version checks before calling version-gated tools.",
+      description: "Get UniFi Network application info. Returns: applicationVersion. NOTE: verified against 10.5.43 on a UniFi OS console — the Integration API returns ONLY applicationVersion here; there is no isUniFiOSConsole or other field. Use for: version checks before calling version-gated tools.",
       inputSchema: {},
       outputSchema: getInfoOutputSchema,
       annotations: READ_ONLY,

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -3,7 +3,7 @@
  * field optional, every nested object uses .passthrough() to allow
  * firmware/hardware-specific fields to flow through unchanged).
  *
- * Verified against UniFi Network API 10.4.55. Where the docs collapse
+ * Verified against UniFi Network API 10.5.43. Where the docs collapse
  * nested arrays/objects (e.g. interfaces.ports[], radios[]), the schema
  * uses passthrough records so the contract doesn't lock to fields we
  * haven't verified.
@@ -170,7 +170,7 @@ const WifiBroadcast = z
 
 const ApplicationInfo = z
   .object({
-    // Live-verified (10.4.55): only applicationVersion is returned.
+    // Live-verified (10.5.43): only applicationVersion is returned.
     applicationVersion: z.string().optional(),
   })
   .passthrough();
@@ -350,7 +350,7 @@ const TrafficMatchingList = z
   })
   .passthrough();
 
-// Verified against the live Integration API (10.4.55). The WAN and
+// Verified against the live Integration API (10.5.43). The WAN and
 // site-to-site-tunnel list rows are intentionally minimal in the API.
 const Wan = z
   .object({
@@ -450,9 +450,12 @@ export const listVouchersOutputSchema = {
   data: z.array(Voucher),
 } as const;
 
+// NOTE: the Generate Vouchers endpoint does NOT return the standard
+// paginated envelope. Live-verified (10.5.43): it returns
+// `{ "vouchers": [ ...Voucher ] }` with no offset/limit/count/totalCount.
+// An over-tight schema here (e.g. requiring `data`) hard-fails every call.
 export const createVouchersOutputSchema = {
-  ...PaginationFields,
-  data: z.array(Voucher),
+  vouchers: z.array(Voucher),
 } as const;
 
 export const firewallZoneOutputSchema = FirewallZone.shape;

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -280,6 +280,7 @@ const AclRule = z
     protocolFilter: z.array(z.string()).optional(),
     sourceFilter: z.unknown().optional(),
     destinationFilter: z.unknown().optional(),
+    enforcingDeviceFilter: z.unknown().optional(),
     metadata: Metadata.optional(),
   })
   .passthrough();

--- a/tests/tools/acl.test.ts
+++ b/tests/tools/acl.test.ts
@@ -212,6 +212,32 @@ describe("registerAclTools", () => {
         const callArgs = mockFn(client, "post").mock.calls[0];
         expect(callArgs[1]).not.toHaveProperty("description");
         expect(callArgs[1]).not.toHaveProperty("protocolFilter");
+        expect(callArgs[1]).not.toHaveProperty("sourceFilter");
+        expect(callArgs[1]).not.toHaveProperty("destinationFilter");
+        expect(callArgs[1]).not.toHaveProperty("enforcingDeviceFilter");
+      });
+
+      it("should pass through source/destination/enforcingDevice filters when provided", async () => {
+        mockFn(client, "post").mockResolvedValue({ id: "rule3" });
+
+        const handler = handlers.get("unifi_create_acl_rule");
+        await handler({
+          siteId: "site123",
+          type: "IPV4",
+          name: "Filtered rule",
+          enabled: true,
+          action: "BLOCK",
+          sourceFilter: { type: "NETWORK", value: "n1" },
+          destinationFilter: { type: "IP", value: "10.0.0.1" },
+          enforcingDeviceFilter: { type: "ALL" },
+        });
+
+        const callArgs = mockFn(client, "post").mock.calls[0];
+        expect(callArgs[1]).toMatchObject({
+          sourceFilter: { type: "NETWORK", value: "n1" },
+          destinationFilter: { type: "IP", value: "10.0.0.1" },
+          enforcingDeviceFilter: { type: "ALL" },
+        });
       });
 
       it("should return error when client.post fails", async () => {

--- a/tests/utils/output-schemas.test.ts
+++ b/tests/utils/output-schemas.test.ts
@@ -9,6 +9,7 @@ import {
   firewallPolicyOutputSchema,
   voucherOutputSchema,
   createVouchersOutputSchema,
+  aclRuleOutputSchema,
   lagOutputSchema,
   getInfoOutputSchema,
   listDpiCategoriesOutputSchema,
@@ -188,5 +189,18 @@ describe("output schemas", () => {
       ],
     };
     expect(() => z.object(createVouchersOutputSchema).parse(real)).not.toThrow();
+  });
+
+  it("acl rule schema accepts source/destination/enforcingDevice filters", () => {
+    expect(() =>
+      z.object(aclRuleOutputSchema).parse({
+        id: "a1",
+        type: "IPV4",
+        action: "BLOCK",
+        sourceFilter: { type: "NETWORK", value: "n1" },
+        destinationFilter: null,
+        enforcingDeviceFilter: { type: "ALL" },
+      })
+    ).not.toThrow();
   });
 });

--- a/tests/utils/output-schemas.test.ts
+++ b/tests/utils/output-schemas.test.ts
@@ -8,6 +8,7 @@ import {
   networkOutputSchema,
   firewallPolicyOutputSchema,
   voucherOutputSchema,
+  createVouchersOutputSchema,
   lagOutputSchema,
   getInfoOutputSchema,
   listDpiCategoriesOutputSchema,
@@ -164,7 +165,28 @@ describe("output schemas", () => {
       z.object(lagOutputSchema).parse({ id: "l1", type: "LOCAL" })
     ).not.toThrow();
     expect(() =>
-      z.object(getInfoOutputSchema).parse({ applicationVersion: "10.4.55" })
+      z.object(getInfoOutputSchema).parse({ applicationVersion: "10.5.43" })
     ).not.toThrow();
+  });
+
+  it("create-voucher schema accepts the real Generate Vouchers response (live-captured 10.5.43)", () => {
+    // Captured live: POST /hotspot/vouchers returns { vouchers: [...] } —
+    // NOT a paginated { data: [...] } envelope. `code` is a STRING despite
+    // the docs sample rendering it as a bare number. Regression guard against
+    // the previous `{ ...pagination, data }` schema that hard-failed every call.
+    const real = {
+      vouchers: [
+        {
+          id: "d685adca-bef6-435f-9039-33f08663129f",
+          createdAt: "2026-06-21T01:26:20Z",
+          name: "shape-test",
+          code: "8744293332",
+          authorizedGuestCount: 0,
+          expired: false,
+          timeLimitMinutes: 1,
+        },
+      ],
+    };
+    expect(() => z.object(createVouchersOutputSchema).parse(real)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Aligns the MCP server with **UniFi Network Integration API 10.5.43** (from 10.4.55). The public API surface is **unchanged** — 0 endpoint adds/removes/path changes, and all visible enums/constraints match. The substantive changes are two schema/parameter corrections surfaced by diffing the 10.5.43 docs and verifying shapes against the **live API**.

## Commits (split by concern)

### `fix:` correct create-voucher output schema
The Generate Vouchers endpoint returns `{ "vouchers": [...] }`, **not** the paginated `{ ...pagination, data: [...] }` envelope. Since `data` was required, the previous schema **hard-failed every `create_voucher` call** with `MCP error -32602`. Live-verified the real shape (and confirmed `code` is a **string** despite the docs sample rendering it as a bare number — so `z.string()` correctly stays). Also bumps "verified against" labels 10.4.55 → 10.5.43.

### `feat(acl):` source/destination/enforcing-device filters
Adds `sourceFilter`, `destinationFilter`, and `enforcingDeviceFilter` as optional writable params on **create/update ACL rule** — documented request fields in 10.5.43 that the tools previously couldn't set. Passed through as opaque objects (same pattern as the firewall `policy` field); `enforcingDeviceFilter` also added to the ACL output schema.

## Verification
- **Endpoint diff:** 73 documented, 0 changed vs implementation
- **Raw API** (curl, bypassing MCP validation): minted → inspected → deleted a throwaway voucher; confirmed `{vouchers:[...]}` + string `code`
- **Live MCP** (post-reconnect, exercises `validateToolOutput`): `list_vouchers`, `get_voucher`, `list_devices`, `list_clients` all return real data with **no `-32602`**
- **typecheck ✓ · lint ✓ · 689 tests pass** — incl. regression tests using the live-captured voucher response + ACL filters

> Note: docs extraction + live verification ran against a console reporting `applicationVersion: 10.5.43`.

## Summary by Sourcery

Align UniFi MCP server schemas and tooling with UniFi Network Integration API 10.5.43 while keeping the public API surface unchanged.

Bug Fixes:
- Correct the create-voucher output schema to match the real Generate Vouchers response shape, preventing MCP validation failures for voucher creation.

Enhancements:
- Add support for source, destination, and enforcing-device filters in ACL rule create/update tools and schemas, matching newly documented Integration API fields.
- Extend ACL and voucher output schemas and tests based on live 10.5.43 responses to ensure future regressions are caught early.
- Refresh tool and schema documentation strings to indicate verification against UniFi Network API 10.5.43 across devices, clients, WANs, VPNs, and system info.

Tests:
- Add regression tests for the corrected create-voucher response schema using live-captured 10.5.43 data.
- Add tests to verify ACL rule tools pass through source/destination/enforcing-device filters and that the ACL rule schema accepts them.