### PR TITLE
ci: install pnpm as standalone binary in action-setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          standalone: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
@@ -37,6 +39,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          standalone: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          standalone: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc


### PR DESCRIPTION
## Summary

Adds `standalone: true` to each `pnpm/action-setup` step so pnpm is installed as a self-contained binary (`@pnpm/exe`) rather than relying on the runner's ambient Node. Fleet-wide CI hardening.

- **ci.yml**: 2 blocks (lint/typecheck job + test matrix job)
- **release.yml**: 1 block (publish job)

Each `standalone: true` is placed on the `pnpm/action-setup` step, ordered before its `setup-node` step.

## Release impact

Uses a `ci:` conventional-commit prefix, so release-please treats this as a non-releasable unit (no version bump).

## Summary by Sourcery

Configure GitHub Actions workflows to use pnpm as a standalone binary in CI and release jobs.

CI:
- Enable standalone pnpm installation in ci.yml lint/typecheck and test matrix jobs using pnpm/action-setup.
- Enable standalone pnpm installation in release.yml publish job using pnpm/action-setup.