### PR TITLE
docs: audit corrections + report real version in serverInfo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ MCP server exposing UniFi Network's Integration API as tool calls. Built with th
 
 ## Local dev setup
 
-- Node version pinned in `.nvmrc` (24.15.0). Use [fnm](https://github.com/Schniz/fnm) — `fnm use` auto-reads `.nvmrc` on `cd`. The published library declares broader `engines.node` (`^22.13.0 || ^24.0.0`) for consumers; the `.nvmrc` only pins *development*.
+- Node version pinned in `.nvmrc` (24.18.0). Use [fnm](https://github.com/Schniz/fnm) — `fnm use` auto-reads `.nvmrc` on `cd`. The published library declares broader `engines.node` (`^22.13.0 || ^24.0.0`) for consumers; the `.nvmrc` only pins *development*.
 - Package manager: pnpm via Corepack. `corepack enable`, then `pnpm install`.
 - Dev install/build use pnpm; **publishing uses `npm publish --provenance`** (hybrid — npm has the most battle-tested OIDC flow).
 
@@ -48,17 +48,19 @@ src/
     responses.ts      # formatSuccess() / formatError() helpers
     query.ts          # buildQuery() for pagination/filter params
     safety.ts         # Tool annotations, formatDryRun(), requireConfirmation()
+    output-schemas.ts # Zod output schemas for tools' structuredContent (58 tools)
 ```
 
 ## Adding a new tool
 
-1. Add a function `registerXTools(server, client, readOnly)` in `src/tools/<domain>.ts`
-2. Use `server.registerTool(name, { description, inputSchema, annotations }, handler)`
+1. Add a function `registerXTools(server, client, readOnly = false)` in `src/tools/<domain>.ts`. Domains with **only** read tools (`system`, `sites`, `switching`, `supporting`) omit the `readOnly` param entirely — there is nothing to gate
+2. Use `server.registerTool(name, { description, inputSchema, outputSchema, annotations }, handler)`
 3. Set appropriate annotations from `utils/safety.ts`: `READ_ONLY`, `WRITE`, `WRITE_NOT_IDEMPOTENT`, `DESTRUCTIVE`
-4. For write tools: register them after `if (readOnly) return;` at the function level, add optional `dryRun` parameter
-5. For dangerous/destructive tools: add `confirm` parameter validated via `requireConfirmation()`, prefix description with `DESTRUCTIVE:`
-6. Wire it into `src/tools/index.ts` via `registerAllTools()`
-7. Add tests in `tests/tools/<domain>.test.ts` using `createMockServer()` and `createMockClient()` from `tests/tools/_helpers.ts`
+4. Add an `outputSchema` from `utils/output-schemas.ts` and return `formatSuccess(data, { structured: true })`. Every read tool has one; write tools get one when the API response returns the affected resource. Follow the loose strategy in that file: non-key fields optional, nested objects `.passthrough()`
+5. For write tools: register them after `if (readOnly) return;` at the function level, add optional `dryRun` parameter
+6. For dangerous/destructive tools: add `confirm` parameter validated via `requireConfirmation()`, prefix description with `DESTRUCTIVE:`
+7. Wire it into `src/tools/index.ts` via `registerAllTools()`
+8. Add tests in `tests/tools/<domain>.test.ts` using `createMockServer()` and `createMockClient()` from `tests/tools/_helpers.ts`
 
 ## Tool safety
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An MCP (Model Context Protocol) server that exposes the UniFi Network Integratio
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22.13+ or 24 (see `engines` in `package.json`)
 - A UniFi Network console with the Integration API enabled
 - An API key generated from your UniFi Network console
 
@@ -22,13 +22,14 @@ Use `-s user` for global availability across all projects, or `-s project` for t
 
 ### From source
 
-If you prefer to build locally:
+If you prefer to build locally, this project uses pnpm via Corepack — use `pnpm install`, not `npm install`, which ignores `pnpm-lock.yaml` and resolves different dependency versions:
 
 ```bash
 git clone https://github.com/owine/unifi-network-mcp.git
 cd unifi-network-mcp
-npm install
-npm run build
+corepack enable
+pnpm install
+pnpm run build
 ```
 
 Then add to Claude Code:
@@ -73,15 +74,21 @@ This server provides layered safety controls for responsible operation:
 - **Tool annotations** — Every tool declares `readOnlyHint`, `destructiveHint`, and `idempotentHint` so MCP clients (like Claude Code) can make informed confirmation decisions
 - **Read-only mode** — Enabled by default. Only read operations (list, get) are registered. Set `UNIFI_NETWORK_READ_ONLY=false` to enable write/mutating tools
 - **Destructive tool warnings** — Tools that delete or irreversibly modify resources have descriptions prefixed with `DESTRUCTIVE:` to clearly signal risk
-- **Confirmation parameter** — The most dangerous tools (e.g., `unifi_remove_device`, `unifi_bulk_delete_vouchers`) require an explicit `confirm: true` parameter that must be present for the call to succeed
-- **Dry-run support** — All write tools accept an optional `dryRun: true` parameter that returns a preview of the HTTP request (method, path, body) without making any changes
+- **Confirmation parameter** — Every tool marked `DESTRUCTIVE:` (all 10 of them, including `unifi_remove_device` and `unifi_bulk_delete_vouchers`) requires an explicit `confirm: true` parameter for the call to succeed
+- **Dry-run support** — All 33 write tools accept an optional `dryRun: true` parameter that returns a preview of the HTTP request (method, path, body) without making any changes
+
+## Structured Output
+
+58 of the 74 tools (all 41 read tools, plus the 17 write tools whose API responses return the affected resource) declare an MCP `outputSchema` and return `structuredContent` alongside the usual text content. Clients that understand structured output get typed, machine-readable results instead of parsing JSON out of a text blob.
+
+The schemas live in `src/utils/output-schemas.ts` and are verified against UniFi Network API 10.5.43. They deliberately use a **loose strategy**: every non-key field is optional and nested objects use `.passthrough()`, so firmware- and hardware-specific fields flow through unchanged rather than being stripped or triggering a validation error. This keeps the contract stable across console versions and hardware models.
 
 ## Tools (74 total)
 
 ### System (1)
 | Tool | Description |
 |---|---|
-| `unifi_get_info` | Get application information including version and whether it's a UniFi OS Console |
+| `unifi_get_info` | Get UniFi Network application info — returns `applicationVersion` only |
 
 ### Sites (1)
 | Tool | Description |
@@ -207,11 +214,15 @@ This server provides layered safety controls for responsible operation:
 ## Development
 
 ```bash
-npm run build        # Compile TypeScript
-npm start            # Run the server
-npm run typecheck    # Type-check without emitting
-npm run lint         # ESLint
-npm test             # Run all tests (vitest)
+pnpm install           # Install dependencies
+pnpm run build         # Compile TypeScript
+pnpm start             # Run the server
+pnpm run typecheck     # Type-check without emitting
+pnpm run lint          # ESLint
+pnpm run lint:fix      # ESLint with auto-fix
+pnpm test              # Run all tests (vitest)
+pnpm run test:watch    # Run tests in watch mode
+pnpm run test:coverage # Run tests with coverage
 ```
 
 ### Commit conventions

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
+import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { loadConfig } from "./config.js";
 import { NetworkClient } from "./client.js";
 import { registerAllTools } from "./tools/index.js";
+
+// Read at runtime rather than importing: package.json sits outside rootDir,
+// so a static import would emit dist/src/ and break the published layout.
+const { version } = createRequire(__filename)("../package.json") as {
+  version: string;
+};
 
 async function main() {
   const config = loadConfig();
@@ -11,7 +18,7 @@ async function main() {
 
   const server = new McpServer({
     name: "unifi-network",
-    version: "1.0.0",
+    version,
   });
 
   registerAllTools(server, client, config.readOnly);

--- a/tests/docs-drift.test.ts
+++ b/tests/docs-drift.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createMockServer, createMockClient } from "./tools/_helpers.js";
+import { registerAllTools } from "../src/tools/index.js";
+
+/**
+ * Documentation drift meta-test.
+ *
+ * README.md states an inventory of tools and several exact counts. Those are
+ * prose, so nothing but this test stops them drifting from the code — which is
+ * precisely what happened before (a tool description documented a field the
+ * API never returned, and the Node version contradicted package.json).
+ *
+ * Every number asserted here is derived from the registered tools, never
+ * hardcoded twice. Add a tool and forget the README, and this fails.
+ *
+ * If a rewrite makes a regex below stop matching, the test fails loudly rather
+ * than silently passing — update the pattern, don't delete the check.
+ */
+
+const README = readFileSync(join(process.cwd(), "README.md"), "utf8");
+
+interface ToolEntry {
+  name: string;
+  annotations: Record<string, unknown>;
+  hasOutputSchema: boolean;
+}
+
+function collectTools(): ToolEntry[] {
+  const { server, configs } = createMockServer();
+  registerAllTools(server, createMockClient(), false);
+
+  return [...configs].map(([name, config]) => ({
+    name,
+    annotations: config.annotations,
+    hasOutputSchema: config.outputSchema !== undefined,
+  }));
+}
+
+/** Pull a single number out of the README, failing clearly if absent. */
+function readmeNumber(pattern: RegExp): number {
+  const match = pattern.exec(README);
+  if (!match) {
+    throw new Error(
+      `README.md has no text matching ${String(pattern)} — the wording changed. ` +
+        `Update this pattern so the count stays covered.`
+    );
+  }
+  return Number(match[1]);
+}
+
+/** The "## Tools (N total)" section, up to the next h2. */
+function toolsSection(): string {
+  const match = /^## Tools \(\d+ total\)$([\s\S]*?)^## /m.exec(README);
+  if (!match) throw new Error("README.md has no '## Tools (N total)' section");
+  return match[1];
+}
+
+describe("documentation drift", () => {
+  let allTools: ToolEntry[];
+  let readTools: ToolEntry[];
+  let writeTools: ToolEntry[];
+  let destructiveTools: ToolEntry[];
+
+  beforeAll(() => {
+    allTools = collectTools();
+    readTools = allTools.filter((t) => t.annotations.readOnlyHint === true);
+    writeTools = allTools.filter((t) => t.annotations.readOnlyHint === false);
+    destructiveTools = allTools.filter(
+      (t) => t.annotations.destructiveHint === true
+    );
+  });
+
+  // ── Tool inventory ─────────────────────────────────────────────────
+
+  describe("tool inventory", () => {
+    it("should document every registered tool, and no others", () => {
+      const documented = [
+        ...toolsSection().matchAll(/^\| `(unifi_[a-z_]+)` \|/gm),
+      ]
+        .map((m) => m[1])
+        .sort();
+      const registered = allTools.map((t) => t.name).sort();
+
+      expect(documented).toEqual(registered);
+    });
+
+    it("should not document the same tool twice", () => {
+      const documented = [
+        ...toolsSection().matchAll(/^\| `(unifi_[a-z_]+)` \|/gm),
+      ].map((m) => m[1]);
+
+      expect(documented).toEqual([...new Set(documented)]);
+    });
+
+    it("should give each domain heading a count matching its table rows", () => {
+      // "### Devices (8)" must be followed by exactly 8 tool rows.
+      const chunks = toolsSection().split(/^### /m).slice(1);
+      expect(chunks.length).toBeGreaterThan(0);
+
+      const mismatches = chunks
+        .map((chunk) => {
+          const heading = /^(.+?) \((\d+)\)$/m.exec(chunk);
+          if (!heading) {
+            throw new Error(
+              `Tools section has a '### ' heading without a '(count)': ${chunk.split("\n")[0]}`
+            );
+          }
+          return {
+            heading: heading[1],
+            claimed: Number(heading[2]),
+            actual: [...chunk.matchAll(/^\| `unifi_[a-z_]+` \|/gm)].length,
+          };
+        })
+        .filter((s) => s.claimed !== s.actual);
+
+      expect(mismatches).toEqual([]);
+    });
+  });
+
+  // ── Headline counts ────────────────────────────────────────────────
+
+  describe("headline counts", () => {
+    it("should state the real tool total in the intro", () => {
+      expect(readmeNumber(/Provides (\d+) tools/)).toBe(allTools.length);
+    });
+
+    it("should state the real tool total in the Tools heading", () => {
+      expect(readmeNumber(/## Tools \((\d+) total\)/)).toBe(allTools.length);
+    });
+  });
+
+  // ── Safety claims ──────────────────────────────────────────────────
+
+  describe("safety claims", () => {
+    it("should state the real number of write tools accepting dryRun", () => {
+      expect(readmeNumber(/All (\d+) write tools accept/)).toBe(
+        writeTools.length
+      );
+    });
+
+    it("should state the real number of destructive tools requiring confirm", () => {
+      expect(readmeNumber(/\(all (\d+) of them/)).toBe(destructiveTools.length);
+    });
+  });
+
+  // ── Structured output claims ───────────────────────────────────────
+
+  describe("structured output claims", () => {
+    it("should state the real number of tools declaring an outputSchema", () => {
+      const withSchema = allTools.filter((t) => t.hasOutputSchema);
+      expect(readmeNumber(/^(\d+) of the \d+ tools/m)).toBe(withSchema.length);
+    });
+
+    it("should state the real tool total alongside the outputSchema count", () => {
+      expect(readmeNumber(/^\d+ of the (\d+) tools/m)).toBe(allTools.length);
+    });
+
+    it("should state the real number of read tools declaring an outputSchema", () => {
+      const readWithSchema = readTools.filter((t) => t.hasOutputSchema);
+      expect(readmeNumber(/all (\d+) read tools/)).toBe(readWithSchema.length);
+    });
+
+    it("should state the real number of write tools declaring an outputSchema", () => {
+      const writeWithSchema = writeTools.filter((t) => t.hasOutputSchema);
+      expect(readmeNumber(/plus the (\d+) write tools/)).toBe(
+        writeWithSchema.length
+      );
+    });
+  });
+});

--- a/tests/tools/_helpers.ts
+++ b/tests/tools/_helpers.ts
@@ -7,6 +7,8 @@ interface ToolConfig {
   description: string;
   annotations: Record<string, unknown>;
   schema: Record<string, unknown>;
+  /** Undefined when the tool declares no outputSchema. */
+  outputSchema?: Record<string, unknown>;
 }
 
 /**
@@ -14,7 +16,7 @@ interface ToolConfig {
  * Returns maps from tool name → handler function and tool name → config.
  *
  * server.registerTool() is called as:
- *   server.registerTool(name, { description, inputSchema, annotations }, handler)
+ *   server.registerTool(name, { description, inputSchema, outputSchema, annotations }, handler)
  */
 export function createMockServer() {
   const handlers = new Map<string, (...args: any[]) => any>();
@@ -26,6 +28,7 @@ export function createMockServer() {
         config: {
           description?: string;
           inputSchema?: Record<string, unknown>;
+          outputSchema?: Record<string, unknown>;
           annotations?: Record<string, unknown>;
         },
         handler: (...a: any[]) => any,
@@ -34,6 +37,7 @@ export function createMockServer() {
           description: config.description ?? "",
           annotations: config.annotations ?? {},
           schema: config.inputSchema ?? {},
+          outputSchema: config.outputSchema,
         });
         handlers.set(name, handler);
       },


### PR DESCRIPTION
Audit of `README.md` and `CLAUDE.md` against the source. Every claim was checked rather than read for style.

**The tool documentation was already perfect** — all 74 tool names match the 74 registered in `src/tools/` exactly, every per-domain count is right, and the safety claims hold (all 33 write tools really do accept `dryRun`; all 10 `DESTRUCTIVE:` tools really do require `confirm`). The errors were in the parts nobody revisits.

## Wrong — contradicted the source

- **`Node.js 20+`** → `engines` requires `^22.13.0 || ^24.0.0`. The npx quick start failed for anyone on Node 20. Highest user impact.
- **`unifi_get_info`** was documented as returning "whether it's a UniFi OS Console". It doesn't. The tool's own description in `src/tools/system.ts` has said so since it was verified against 10.5.43 — someone fixed the tool and the README kept the pre-verification claim.
- **`.nvmrc`** documented as 24.15.0; actually 24.18.0.

## Contradictions between the docs

- "From source" used `npm install` while CLAUDE.md mandates pnpm via Corepack. The repo ships `pnpm-lock.yaml` and pins `packageManager`, so `npm install` silently resolved different versions.
- CLAUDE.md gave `registerXTools(server, client, readOnly)` as the universal signature, but the four all-read-only domains (`system`, `sites`, `switching`, `supporting`) omit `readOnly` — there's nothing to gate.
- Dev commands omitted `test:watch`, `test:coverage`, `lint:fix`.

## Largest gap: structured output was undocumented

58 of 74 tools declare an `outputSchema` and return `structuredContent`, with a dedicated `tests/utils/output-schemas.test.ts` — and neither doc mentioned it. `output-schemas.ts` was missing from the architecture tree, and the "Adding a new tool" recipe never told you to add one, so following it produced a tool inconsistent with the other 58.

Now documented, including the **loose schema strategy** (non-key fields optional, nested objects `.passthrough()`) — the non-obvious bit, which exists so firmware-specific fields flow through instead of being stripped.

## `fix:` commit — serverInfo reported v1.0.0

Separate commit because it needs to trigger a release; a `docs:`-only PR wouldn't ship it.

`src/index.ts` hardcoded `version: "1.0.0"` while `package.json` is at 2.8.3 — every MCP client has been told this server is v1.0.0 for eight releases. release-please bumps `package.json` but can't reach a string literal. Now read via `createRequire`; a static import would put `package.json` outside `rootDir` and emit `dist/src/`, breaking the published layout.

## Verification

Typecheck, lint, and all 689 tests pass — but none of those would catch the version fix, so I drove the real stdio handshake:

```
{"serverInfo":{"name":"unifi-network","version":"2.8.3"}}
```

Also confirmed the two things that could break silently: `dist/` still emits flat, and `package.json` is in the published tarball, so `../package.json` resolves for npx consumers and not just locally.

## Note

`output-schemas.ts`'s header comment says "high-value read tools", but 17 write tools use it too. Left alone as out of scope, but it's the same class of drift.

## Summary by Sourcery

Align documentation with the current Node.js and tooling setup and ensure the server reports the actual package version in MCP serverInfo.

Enhancements:
- Make the MCP server version in serverInfo dynamically read from package.json instead of a hardcoded value.

Documentation:
- Correct README and CLAUDE.md prerequisites to match the Node.js engine and .nvmrc versions used by the project.
- Update local build and development instructions to mandate pnpm/Corepack, expand dev scripts, and clarify tool registration patterns.
- Document structured output support, including the use of output schemas and the loose schema strategy, and add output-schemas.ts to the architecture overview.
- Fix the description of the unifi_get_info tool to accurately reflect the data it returns.