### PR TITLE
ci: migrate pnpm/action-setup to pnpm/setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      # `install: false` — pnpm/setup installs by default; each job runs its own
+      # explicit `pnpm install --frozen-lockfile` below.
+      - uses: pnpm/setup@c9883cc79df532ad1a7b81bf9ab944ceb090d65c # v2.0.0
         with:
-          standalone: true
+          install: false
+      # Kept ahead of setup-node so `cache: pnpm` can resolve the pnpm store path.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
@@ -38,9 +41,11 @@ jobs:
           - '24.18.1' # renovate: datasource=node-version depName=node-lts-24 packageName=node
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@c9883cc79df532ad1a7b81bf9ab944ceb090d65c # v2.0.0
         with:
-          standalone: true
+          install: false
+      # setup-node stays: pnpm/setup's `runtime` input can't drive the
+      # Renovate-annotated node matrix above.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,12 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/setup@c9883cc79df532ad1a7b81bf9ab944ceb090d65c # v2.0.0
         with:
-          standalone: true
+          install: false
+      # setup-node is required here regardless of pnpm/setup: it writes the
+      # .npmrc that `registry-url` + NODE_AUTH_TOKEN need for `npm publish`.
+      # pnpm/setup's `runtime` input does not configure registry auth.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc


### PR DESCRIPTION
Ports all three `pnpm/action-setup` call sites to the successor action, [`pnpm/setup`](https://github.com/pnpm/setup), per the [migration guide](https://github.com/pnpm/action-setup#migrating-to-pnpmsetup).

Pinned to `c9883cc79df532ad1a7b81bf9ab944ceb090d65c # v2.0.0` (SHA-pinned with the trailing version comment so Renovate keeps tracking it).

## Changes, at each of the three sites

| Site | Job |
|---|---|
| `.github/workflows/ci.yml` | `lint` |
| `.github/workflows/ci.yml` | `test-matrix` |
| `.github/workflows/release.yml` | `publish` |

- **Dropped `standalone: true`** — `pnpm/setup` always uses the standalone native executable, so the input no longer exists.
- **Added `install: false`** — this is the one input that is *not* a no-op. `pnpm/setup`'s `install` defaults to **true** (it auto-installs whenever a `package.json` is present), inverting `run_install`'s old default. Without `install: false`, every job would run a non-frozen `pnpm install` immediately before its own explicit `pnpm install --frozen-lockfile`. That's not merely wasted time: the first install could silently reconcile a drifted lockfile, after which the frozen check would pass and stop catching drift.
- **Left `cache` at its default (`false`)** so the pnpm store isn't cached twice alongside `setup-node`'s `cache: pnpm`.
- **Preserved step ordering** (`pnpm/setup` before `actions/setup-node`). `setup-node`'s `cache: pnpm` shells out to `pnpm store path` to locate the store, so pnpm must already be on `PATH`.

## Why `actions/setup-node` stays at all three sites

`pnpm/setup`'s new `runtime` input can install Node, but it does not replace `setup-node` here:

- **ci.yml** — `runtime:` can't read `.nvmrc` (the `lint` job) and can't cleanly drive the Renovate-annotated `node-version` matrix (`22.23.2` / `24.18.1`). Consolidating those is a separate decision, deliberately out of scope for this port.
- **release.yml** — `setup-node` is *required* regardless. It writes the `.npmrc` that `registry-url` + `NODE_AUTH_TOKEN` depend on for `npm publish --provenance`. `runtime` does not configure registry auth, so removing `setup-node` would break publishing.

## Version floor

`pnpm/setup` v2 hard-rejects pnpm below v11 with an error. This repo declares `packageManager: pnpm@11.19.0` and passes no `version` input, so pnpm is resolved from `packageManager` and satisfies the floor.

## Verification — read this before merging

CI green on this PR exercises **only the two ci.yml sites**. The `release.yml` change is **not** covered:

- `release.yml` triggers on `workflow_run` after CI completes on `main`, and its `publish` job additionally gates on `release_created == 'true'`. Neither fires for a PR.
- So the migrated publish path — `pnpm/setup` + `setup-node`'s `registry-url` `.npmrc` + `npm publish --provenance` — is **unverified by this PR** and will first execute for real on the next release-please release.

Treat the release.yml hunk as reviewed-by-inspection, not tested. The specific risk to watch on the next release is npm auth: if `install: false` or the action swap perturbed anything about how `.npmrc`/`NODE_AUTH_TOKEN` are set up, it surfaces as a `publish` failure rather than a bad artifact.

## Soak-window note

`pnpm/setup` v2.0.0 was published **2026-08-04**, i.e. day zero relative to this fleet's 3-day Renovate soak window. Pinning v2 now was an explicit call, taken knowingly over the alternative of pinning v1.0.0 and letting Renovate bump after the soak.

## Summary by Sourcery

Migrate GitHub workflows from pnpm/action-setup to the pnpm/setup v2.0.0 action while preserving existing Node setup and caching behavior.

Build:
- Pin pnpm/setup to v2.0.0 via commit SHA in all workflows that previously used pnpm/action-setup.

CI:
- Update lint, test-matrix, and release publish jobs to use pnpm/setup with explicit install: false to avoid implicit installs and maintain frozen lockfile checks.
- Retain actions/setup-node in CI and release workflows for Node version management, caching, and registry authentication responsibilities.